### PR TITLE
Support building dtasm3 for ESP32

### DIFF
--- a/runtime/dtasm3/CMakeLists.txt
+++ b/runtime/dtasm3/CMakeLists.txt
@@ -18,6 +18,7 @@ include_directories(
         ${PROJECT_SOURCE_DIR}/src
         ${PROJECT_SOURCE_DIR}/../../lib/dtasm_abi/include
         ${PROJECT_SOURCE_DIR}/../../third_party/flatbuffers.git/include
+        ${PROJECT_SOURCE_DIR}/../../third_party/wasm3.git/platforms/embedded/esp32-idf-wasi/main
 )
 
 file(GLOB all_srcs
@@ -25,12 +26,19 @@ file(GLOB all_srcs
         "${PROJECT_SOURCE_DIR}/src/*.cpp"
         )
 
-add_library(${target} STATIC ${all_srcs})
+if(ESP_PLATFORM)
+    add_library(${target} STATIC ${all_srcs} ${PROJECT_SOURCE_DIR}/../../third_party/wasm3.git/platforms/embedded/esp32-idf-wasi/main/m3_api_esp_wasi.c)
+else()
+    add_library(${target} STATIC ${all_srcs})
+endif()
 
 target_link_libraries(${target} PRIVATE m3)
+set_target_properties(m3 PROPERTIES COMPILE_FLAGS -Wno-maybe-uninitialized)
+target_compile_definitions(m3 PUBLIC d_m3MaxFunctionStackHeight=4096)
 
-target_compile_options(${target} PUBLIC -g)
 target_compile_definitions(${target} PUBLIC d_m3HasWASI)
-
-target_compile_options(m3 PUBLIC -g)
-target_compile_definitions(m3 PUBLIC d_m3HasWASI)
+if(ESP_PLATFORM)
+    target_compile_definitions(${target} PUBLIC ESP32)
+else()
+    target_compile_definitions(m3 PUBLIC d_m3HasWASI)
+endif()

--- a/runtime/dtasm3/include/dtasm3.h
+++ b/runtime/dtasm3/include/dtasm3.h
@@ -128,6 +128,7 @@ namespace dtasm3
     
     public: 
         ~Runtime();
+        Runtime(const Runtime &rt);
         DtasmModelDescription get_model_description();
         
         DtasmStatus initialize(
@@ -159,6 +160,7 @@ namespace dtasm3
         Module(Impl &impl);
 
     public: 
+        Module(const Module &mod);
         ~Module();
     };
 
@@ -173,6 +175,6 @@ namespace dtasm3
         ~Environment();
         Module load_module(const uint8_t* data, const size_t len);
         Module load_module(std::shared_ptr<std::vector<uint8_t>> data);
-        Runtime create_runtime(Module &mod);
+        Runtime create_runtime(Module &mod, int buffersize = 8192);
     };
 }

--- a/runtime/dtasm3/include/wasm3_cpp.h
+++ b/runtime/dtasm3/include/wasm3_cpp.h
@@ -14,7 +14,11 @@
 #include "m3_env.h"
 
 #if defined(d_m3HasWASI) || defined(d_m3HasMetaWASI) || defined(d_m3HasUVWASI)
+#if defined(ESP32)
+#include "m3_api_esp_wasi.h"
+#else
 #include "m3_api_wasi.h"
+#endif
 #define LINK_WASI
 #endif
 
@@ -147,6 +151,7 @@ namespace wasm3 {
     namespace detail {
         static inline void check_error(M3Result err) {
             if (err != m3Err_none) {
+                std::cout << err << std::endl;
                 throw error(err);
             }
         }
@@ -321,7 +326,11 @@ namespace wasm3 {
             M3Result err = m3_LoadModule(runtime, m_taggedModule->module);
             detail::check_error(err);
 #if defined(LINK_WASI)
+#if defined(ESP32)
+            err = m3_LinkEspWASI(m_taggedModule->module);
+#else
             err = m3_LinkWASI(m_taggedModule->module);
+#endif
             detail::check_error(err);
 #endif
             m_taggedModule->is_loaded = true;

--- a/runtime/dtasm3/src/dtasm3.cpp
+++ b/runtime/dtasm3/src/dtasm3.cpp
@@ -10,6 +10,7 @@
 #include <fstream>
 #include <sstream>
 #include <vector>
+#include <exception>
 
 #define WASM_PAGE_SIZE 65536
 
@@ -21,11 +22,11 @@ namespace DTAPI = DtasmApi;
 
 class dtasm3::Runtime::Impl {
 private: 
-    FB::FlatBufferBuilder m_builder;
     wasm3::runtime m_m3Runtime;
-    int m_buffersize;
-    int32_t m_outputMem;
-    int32_t m_inputMem;
+    FB::FlatBufferBuilder m_builder;
+    size_t m_buffersize;
+    size_t m_outputMem;
+    size_t m_inputMem;
 
     std::unique_ptr<wasm3::function> m_allocFn;
     std::unique_ptr<wasm3::function> m_deallocFn;
@@ -516,6 +517,10 @@ dtasm3::Runtime::Runtime(Impl &impl):
     _rt(std::make_unique<dtasm3::Runtime::Impl>(std::move(impl)))
 {}
 
+// dtasm3::Runtime::Runtime(const Runtime &rt): 
+//     _rt(std::make_unique<dtasm3::Runtime::Impl>(std::move(*rt._rt)))
+// {}
+
 dtasm3::Runtime::~Runtime() = default;
 
 dtasm3::DtasmModelDescription dtasm3::Runtime::get_model_description() {
@@ -580,6 +585,10 @@ dtasm3::Module::Module(Impl &impl):
     _mod{std::make_unique<dtasm3::Module::Impl>(impl)}
 {}
 
+dtasm3::Module::Module(const Module &mod):
+    _mod{std::make_unique<dtasm3::Module::Impl>(*mod._mod)}
+{}
+
 dtasm3::Module::~Module() = default;
 
 
@@ -628,8 +637,8 @@ dtasm3::Module dtasm3::Environment::load_module(std::shared_ptr<std::vector<uint
     return _env->load_module(data);
 }
 
-dtasm3::Runtime dtasm3::Environment::create_runtime(Module &module){
-    return _env->create_runtime(module);
+dtasm3::Runtime dtasm3::Environment::create_runtime(Module &module, int buffersize){
+    return _env->create_runtime(module, buffersize);
 }
 
 dtasm3::Environment::~Environment() = default;

--- a/runtime/examples/dtasm3_main/src/main.cpp
+++ b/runtime/examples/dtasm3_main/src/main.cpp
@@ -17,7 +17,7 @@ class InputParser{
             for (int i=1; i < argc; ++i)
                 this->tokens.push_back(std::string(argv[i]));
         }
-        /// @author iain
+
         const std::string& getCmdOption(const std::string &option) const{
             std::vector<std::string>::const_iterator itr;
             itr = std::find(this->tokens.begin(), this->tokens.end(), option);
@@ -27,7 +27,7 @@ class InputParser{
             static const std::string empty_string("");
             return empty_string;
         }
-        /// @author iain
+
         bool cmdOptionExists(const std::string &option) const{
             return std::find(this->tokens.begin(), this->tokens.end(), option)
                    != this->tokens.end();


### PR DESCRIPTION
Minor build changes that will allow building dtasm3 with ESP-IDF for running on ESP32 WROVER modules.