### PR TITLE
In dtasm3, update memory base pointer after each call into wasm instance

### DIFF
--- a/runtime/dtasm3/src/dtasm3.cpp
+++ b/runtime/dtasm3/src/dtasm3.cpp
@@ -233,6 +233,8 @@ private:
             errMsg << "Response buffer too small; need " << resLen << " bytes, have " << m_buffersize;
             throw std::runtime_error(errMsg.str().c_str());
         }
+        // update memory base pointer to cover the case where wasm memory changed during function call
+        memPtr = m_m3Runtime.get_memory(memSize, 0);
 
         return memPtr + m_outputMem;
     }


### PR DESCRIPTION
Wasm memory may grow dynamically during execution of a function. When this happens, the base memory address visible to the host changes,  but allocations inside the Wasm module that are relative to that base stay intact. Hence, the base memory pointer needs to be updated from the runtime after each Wasm function call. This PR fixes this for dtasm3 (closes #9). 